### PR TITLE
Registered heuristic for PRUDP protocols

### DIFF
--- a/nex-dissector-plugin/nex_dissector.lua
+++ b/nex-dissector-plugin/nex_dissector.lua
@@ -570,9 +570,5 @@ function nex_proto.dissector(buf, pinfo, tree)
 
 	pinfo.cols.info = "NEX " .. info
 end
+nex_proto:register_heuristic("udp",nex_proto.dissector)
 
-udp_table = DissectorTable.get("udp.port")
--- prudpv0
-udp_table:add(60000, nex_proto)
--- prudpv1
-udp_table:add(59900, nex_proto)


### PR DESCRIPTION
This PR is a follow-up from the issue #6 I opened yesterday.
After inspecting the code I found that it didn't worked just because by default dissectors works only on two hardcoded ports, simply registering `nex.proto.dissector` as an [heuristic](https://www.wireshark.org/docs/wsdg_html_chunked/lua_module_Proto.html#lua_fn_proto_register_heuristic_listname__func_) seems to fix the issue and now PRUDP packets are detected on any port.

Said that I don't have much experience with Wireshark and Lua so I don't know if what I did adhere to the best practices for dissectors development, in any case I'm open to any feedback.

Have a good day and thanks for your effort in developing this dissector